### PR TITLE
Updated from NiFi 1.1.0 to 1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
-FROM alpine:3.3
+FROM alpine:3.5
 MAINTAINER Ian Nelson <in2rd.code@gmail.com>
 
 # Install headless JDK from upstream
 RUN     apk add --update openjdk8-jre-base
 
 # Install NiFi and clean-up afterwards
-RUN     wget http://www.gtlib.gatech.edu/pub/apache/nifi/1.1.0/nifi-1.1.0-bin.tar.gz && \
-            tar zxvf nifi-1.1.0-bin.tar.gz && \
-            mv nifi-1.1.0 /home/nifi && \
-            rm nifi-1.1.0-bin.tar.gz
+RUN     wget http://archive.apache.org/dist/nifi/1.1.2/nifi-1.1.2-bin.tar.gz && \
+            tar zxvf nifi-1.1.2-bin.tar.gz && \
+            mv nifi-1.1.2 /home/nifi && \
+            rm nifi-1.1.2-bin.tar.gz
 
 # Set the Java home environment variable
 RUN     export JAVA_HOME=/usr/lib/jvm/java-1.8-openjdk

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains a **Dockerfile** to create a containerized version of [
 
 ### Base Docker Image
 
-* [alpine:3.3](https://hub.docker.com/_/alpine/)
+* [alpine:3.5](https://hub.docker.com/_/alpine/)
 
 
 ### Installation

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker build -t in2rd/docker-nifi:latest -t in2rd/docker-nifi:1.1.0 .
+docker build -t in2rd/docker-nifi:latest -t in2rd/docker-nifi:1.1.2 .


### PR DESCRIPTION
Updated from Alpine 3.3 to 3.5 base image
Changed to Apache dist repository for NiFi source.  The Mirror was unreliable in testing.

Starting with 1.2.0, NiFi intends to support an official Docker Hub image.